### PR TITLE
Auto highlight first child category

### DIFF
--- a/preview-site/components/ProductsMenu.jsx
+++ b/preview-site/components/ProductsMenu.jsx
@@ -13,6 +13,12 @@ export default function ProductsMenu({ root, selectedLeaf, onLeafSelect }) {
     });
   };
 
+  const getDeepestFirstLeaf = (node) => {
+    if (!node) return null;
+    if (!hasChildren(node)) return node;
+    return getDeepestFirstLeaf(node.children[0]);
+  };
+
   const NodeItem = ({ node, depth = 0 }) => {
     if (!node) return null;
     const isParent = hasChildren(node);
@@ -23,7 +29,10 @@ export default function ProductsMenu({ root, selectedLeaf, onLeafSelect }) {
       <div style={{ marginLeft: depth * 12 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
           <span
-            onClick={() => onLeafSelect(node)}
+            onClick={() => {
+              const target = isParent ? getDeepestFirstLeaf(node) : node;
+              if (target) onLeafSelect(target);
+            }}
             style={{
               cursor: "pointer",
               fontWeight: isSelected ? 600 : 500,

--- a/preview-site/pages/preview/[vendorId]/[categoryId].jsx
+++ b/preview-site/pages/preview/[vendorId]/[categoryId].jsx
@@ -82,13 +82,20 @@ const parsedHomeLocations = homeLocs ? JSON.parse(homeLocs) : [];
     const [selectedChild, setSelectedChild] = useState(null);
 
     useEffect(() => {
+      if (!node) return;
+      const getDeepestFirstChild = (n) => {
+        if (!n?.children?.length) return n;
+        return getDeepestFirstChild(n.children[0]);
+      };
       if (node.children?.length > 0) {
-        const defaultParent = node.children[0];
-        setSelectedParent(defaultParent);
-        setSelectedChild(defaultParent.children?.[0] || defaultParent);
+        const firstParent = node.children[0];
+        const firstLeaf = getDeepestFirstChild(firstParent);
+        setSelectedParent(firstParent);
+        setSelectedChild(firstLeaf);
       } else {
+        const firstLeaf = getDeepestFirstChild(node);
         setSelectedParent(node);
-        setSelectedChild(node);
+        setSelectedChild(firstLeaf);
       }
     }, [node]);
 
@@ -114,6 +121,19 @@ const parsedHomeLocations = homeLocs ? JSON.parse(homeLocs) : [];
     }, [selectedLeaf, node]);
 
     const displayNode = selectedChild || selectedParent;
+
+    useEffect(() => {
+      // Ensure when selectedParent changes, selectedChild defaults to its deepest-first leaf
+      if (!selectedParent) return;
+      const getDeepestFirstChild = (n) => {
+        if (!n?.children?.length) return n;
+        return getDeepestFirstChild(n.children[0]);
+      };
+      const leaf = getDeepestFirstChild(selectedParent);
+      if (leaf && selectedChild?.id !== leaf.id) {
+        setSelectedChild(leaf);
+      }
+    }, [selectedParent]);
 
     return (
       <section style={{ marginBottom: 28 }}>
@@ -186,8 +206,14 @@ const parsedHomeLocations = homeLocs ? JSON.parse(homeLocs) : [];
                 <button
                   key={opt.id}
                   onClick={() => {
+                    const getDeepestFirstChild = (n) => {
+                      if (!n?.children?.length) return n;
+                      return getDeepestFirstChild(n.children[0]);
+                    };
                     setSelectedParent(opt);
-                    setSelectedChild(opt.children?.[0] || opt);
+                    const leaf = getDeepestFirstChild(opt);
+                    setSelectedChild(leaf);
+                    if (leaf && onLeafSelect) onLeafSelect(leaf);
                   }}
                   style={{
                     padding: "6px 12px",

--- a/preview-site/pages/preview/[vendorId]/[categoryId].jsx
+++ b/preview-site/pages/preview/[vendorId]/[categoryId].jsx
@@ -74,6 +74,37 @@ const parsedHomeLocations = homeLocs ? JSON.parse(homeLocs) : [];
     return node.children.some((c) => containsId(c, id));
   };
 
+  // ----------------- Initialize selection from route -----------------
+  useEffect(() => {
+    if (!categoryTree || !categoryId) return;
+
+    const findNodeById = (node, id) => {
+      if (!node) return null;
+      if (node.id === id) return node;
+      if (!Array.isArray(node.children)) return null;
+      for (const child of node.children) {
+        const found = findNodeById(child, id);
+        if (found) return found;
+      }
+      return null;
+    };
+
+    const getDeepestFirstChild = (n) => {
+      if (!n?.children?.length) return n;
+      return getDeepestFirstChild(n.children[0]);
+    };
+
+    const routeId = Array.isArray(categoryId) ? categoryId[0] : categoryId;
+    const target = findNodeById(categoryTree, routeId);
+    if (!target) return;
+
+    // If already pointing inside target subtree, keep current selection
+    if (selectedLeaf && containsId(target, selectedLeaf.id)) return;
+
+    const leaf = getDeepestFirstChild(target);
+    if (leaf) setSelectedLeaf(leaf);
+  }, [categoryTree, categoryId]);
+
   // ----------------- Card Component -----------------
   const ParentWithSizesCard = ({ node, selectedLeaf, onLeafSelect }) => {
     if (!node) return null;


### PR DESCRIPTION
Implement deepest-first child auto-selection for category navigation and cards.

This change ensures that when a parent category is opened or selected, its first deepest child is automatically highlighted, fixing inconsistent highlighting behavior for multi-level categories like "Senior" where "L1" should be active by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-154e00d3-ce08-4c2a-a3ae-cb0fb67a3a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-154e00d3-ce08-4c2a-a3ae-cb0fb67a3a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

